### PR TITLE
Moved restore in progress lock

### DIFF
--- a/mariadb/scripts/restore.sh
+++ b/mariadb/scripts/restore.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-touch ${backup_root_dir}/restore_in_progress
-
 backup_filename=${1}
 backup_dir_name="${1%.*}"
 
 backup_root_dir='/backups'
 backup_to_restore="${backup_root_dir}/${backup_filename}"
+
+touch ${backup_root_dir}/restore_in_progress
 
 if [ ! -f "${backup_to_restore}" ]; then
 	echo "Backup file ${backup_to_restore} not found!"


### PR DESCRIPTION
The file wasn't being put in the right spot because the env var wasn't
defined yet.

Signed-off-by: Bill Maxwell <cloudnautique@users.noreply.github.com>