### PR TITLE
Allow directory (image) names to have hyphens

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ This repository houses all of the Acorn library image definitions.
 
 1. If you are using if blocks to deploy an optional component, the if block should add/modify keys in the overall acorn key order.
 1. When merging user provided structs with default structs, place the user provided struct variable first. `args.deploy.userData & {...acorn defined data}`.
+
+## Tagging and publishing images
+
+In this repo, images are built and published based on git tags. The tag contains information about the image to publish and the version to give it. Here are the guidelines for tagging to publish an image:
+- The tag must be of the form: `<image name>/<version>`
+- The `image name` portion must map to a directory name in the repo
+- The `version` portion will be used as the image version. As such, it must conform to image tag restrictions. For example, it cannot contain a `+` symbol.

--- a/scripts/setup_tags.sh
+++ b/scripts/setup_tags.sh
@@ -2,7 +2,8 @@
 
 committed_tag=${GITHUB_REF#refs/*/}
 
-IFS='-' read -r image tag <<< "$committed_tag"
+
+IFS='/' read -r image tag <<< "$committed_tag"
 
 echo "IMAGE=${image}" >> $GITHUB_ENV
 echo "TAG=${tag}" >> $GITHUB_ENV


### PR DESCRIPTION
The script can't handle an image name with a hyphen in it like
hello-world. This change allows it to.

The short-coming of this solution is that it can't handled a hyphen
in the version. So, something like foo-v1.0.0-rc1 wouldn't parse
properly. But I think this is good enough for now, until we actually hit
that usecase.

Signed-off-by: Craig Jellick <craig@acorn.io>
