### PR TITLE
Add CoreDNS Acorn

### DIFF
--- a/coredns/Acornfile
+++ b/coredns/Acornfile
@@ -1,0 +1,22 @@
+args: {
+	// Number of replicas to run
+    scale: 1
+
+    // String of a Corefile to run with
+    corefile: ""
+
+    // Version of CoreDNS to run
+    version: "1.10.0"
+}
+
+containers: {
+    coredns: {
+        scale: args.scale
+        ports: "53/udp"
+        image: "docker.io/coredns/coredns:\(args.version)"
+        if args.corefile != "" {
+            files: "./Corefile": args.corefile
+        }
+    }
+}
+

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -1,0 +1,21 @@
+# CoreDNS Acorn
+
+This Acorn provides a CoreDNS instance. It will serve UDP DNS trafic over port 53.
+
+## Quick start
+
+`acorn run [COREDNS_IMAGE]`
+
+This will create a standalone CoreDNS instance using the default Corefile. If you would like to overwrite the default Corefile, you can do so easily.
+
+`acorn run [COREDNS_IMAGE] --corefile @Corefile`
+
+> **Note**: Everything after @ should be an absolute path to your Corefile. For more information, see [the documentation](https://docs.acorn.io/running/args-and-secrets#passing-complex-arguments) for this Acorn feature.
+
+## Available options
+
+```shell
+--corefile string  String of a Corefile to run with.  Default ("")
+--scale int        Number of replicas to run
+--version  string  Version of CoreDNS to use.         Default ("1.10.0")
+```


### PR DESCRIPTION
This PR creates a simple Acorn wrapper around the [coredns/coredns](https://hub.docker.com/r/coredns/coredns/) image. It allows you to specify a Corefile for further customization of the DNS server.