### PR TITLE
Add --configs flag for allowing a user to specify custom configs for plugins

### DIFF
--- a/coredns/Acornfile
+++ b/coredns/Acornfile
@@ -1,11 +1,11 @@
 args: {
-	// Number of replicas to run
+	// Number of replicas to run (example: --scale 1)
     scale: 1
 
-    // String of a Corefile to run with
-    corefile: ""
+    // YAML file where each key is a filename and its value is the content of that file. (example: --configs @config.yaml)
+    configs: {}
 
-    // Version of CoreDNS to run
+    // Version of CoreDNS to run (example: --version 1.10.0)
     version: "1.10.0"
 }
 
@@ -14,9 +14,21 @@ containers: {
         scale: args.scale
         ports: "53/udp"
         image: "docker.io/coredns/coredns:\(args.version)"
-        if args.corefile != "" {
-            files: "./Corefile": args.corefile
-        }
+        
+        // Since CoreDNS runs in "/" we want to work of a non-root directory,
+        // mount our configs there, and run from that directory.
+        workdir: "/app"
+        dirs: "/app": "secret://coredns-configs"
     }
 }
 
+secrets : {
+    "coredns-configs": {
+        type: "opaque"
+        data: {
+            for k,v in args.configs {
+                "\(k)": "\(v)"
+            }
+        }
+    }
+}

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -1,21 +1,38 @@
 # CoreDNS Acorn
 
-This Acorn provides a CoreDNS instance. It will serve UDP DNS trafic over port 53.
+This Acorn provides a CoreDNS instance. It will serve UDP DNS traffic over port 53.
 
 ## Quick start
 
 `acorn run [COREDNS_IMAGE]`
 
-This will create a standalone CoreDNS instance using the default Corefile. If you would like to overwrite the default Corefile, you can do so easily.
+This will create a standalone CoreDNS instance using the default Corefile. If you would like to overwrite the default Corefile, its a quick two step process.
 
-`acorn run [COREDNS_IMAGE] --corefile @Corefile`
+1. Create a YAML file and write it in such a way where there are only keys and values. Each key will be a config's filename and each value will be its content.
 
-> **Note**: Everything after @ should be an absolute path to your Corefile. For more information, see [the documentation](https://docs.acorn.io/running/args-and-secrets#passing-complex-arguments) for this Acorn feature.
+    ```yaml
+    # configs.yaml
+    Corefile: |
+        {
+            whoami
+            log
+        }
+    foo-config: |
+        bar-data
+    ```
 
-## Available options
+2. Now just run the CoreDNS Acorn and reference that config file with the `--configs` flag. The configs we created will each be written to individual files in the same directory that CoreDNS runs. In this example, we will get both a `Corefile` and a `foo-config` created.
 
-```shell
---corefile string  String of a Corefile to run with.  Default ("")
---scale int        Number of replicas to run
---version  string  Version of CoreDNS to use.         Default ("1.10.0")
+    `acorn run [COREDNS_IMAGE] --configs @configs.yaml`
+
+    > **Note**: Everything after @ should be an absolute path to your configs file. For more information, see [the documentation](https://docs.acorn.io/running/args-and-secrets#passing-complex-arguments) for this Acorn feature.
+
+This process will work for any configs that you could need for CoreDNS or its plugins. 
+
+### Available options
+
+```
+--scale     int     Number of replicas to run                                                         Default (1)
+--version   string  Version of CoreDNS to use.                                                        Default ("1.10.0")
+--configs   object  YAML file where each key is a filename and its value is the content of that file. Default ({})
 ```


### PR DESCRIPTION
This adds a new option, --configs, which allows a user to specify a yaml file of additional config files needed.